### PR TITLE
[CMS PR 33100] Add update SQL scripts

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-05-01.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-05-01.sql
@@ -1,0 +1,4 @@
+UPDATE `#__template_styles`
+   SET `params` = '{"hue":"hsl(214, 63%, 20%)","bg-light":"#f0f4fb","text-dark":"#495057","text-light":"#ffffff","link-color":"#2a69b8","special-color":"#001b4c","monochrome":"0","loginLogo":"","loginLogoAlt":"","logoBrandLarge":"","logoBrandLargeAlt":"","logoBrandSmall":"","logoBrandSmallAlt":""}'
+ WHERE `template` = 'atum'
+   AND `client_id` = 1;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-01.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-01.sql
@@ -1,0 +1,4 @@
+UPDATE "#__template_styles"
+   SET "params" = '{"hue":"hsl(214, 63%, 20%)","bg-light":"#f0f4fb","text-dark":"#495057","text-light":"#ffffff","link-color":"#2a69b8","special-color":"#001b4c","monochrome":"0","loginLogo":"","loginLogoAlt":"","logoBrandLarge":"","logoBrandLargeAlt":"","logoBrandSmall":"","logoBrandSmallAlt":""}'
+ WHERE "template" = 'atum'
+   AND "client_id" = 1;


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/33100 .

### Summary of Changes

This PR here adds an update SQL script for each database type to set the template style parameters when updating a 4.0 Beta 7 or earlier 4.0 Beta to Beta 8 or RC, where hopefully the CMS PR will be included.

The update statement will set the parameters for ALL template styles of the Atum template, i.e. also for copied template styles, and it replaces all previously saved parameters.

I can change that to only update if the parameters are empty, and also to work only on the one with the lowest ID, i.e. not on copies, but I think that's not necessary.

If it's ok or not we can discuss in the CMS PR.

The description of the CMS PR and maybe also later the release announcement of the Beta or RC where the CMS PR will be included should be updated by the information that any previously saved parameters for template styles of the Atum template will be overwritten when updating a previous 4.0 Beta, and then it should be fine.